### PR TITLE
Added Mac Compile Text

### DIFF
--- a/1_Introduction_to_SDL/main.cpp
+++ b/1_Introduction_to_SDL/main.cpp
@@ -1,18 +1,26 @@
 // On linux compile with:
 // g++ -std=c++17 main.cpp -o prog -lSDL2
 
+// On mac (assuming a brew install of SDL2-- "brew install sdl2" in the command line) you can compile with:
+// clang++ main.cpp -I$HOMEBREW_CELLAR/sdl2/2.26.1/include (includes the headers) -L$HOMEBREW_CELLAR/sdl2/2.26.1/lib -lSDL2-2.0.0 (these two include the library)
+// "2.26.1" would be replaced by the current version of SDL2 you have installed which can be found in the
+// /opt/homebrew/Cellar/sdl2 folder
+
 // C++ Standard Libraries
 #include <iostream>
 
 // Third-party library
 #include <SDL2/SDL.h>
 
-int main(int argc, char* argv[]){
+int main(int argc, char *argv[])
+{
 
-    if(SDL_Init(SDL_INIT_VIDEO) < 0){
-        std::cout << "SDL could not be initialized: " <<
-                  SDL_GetError();
-    }else{
+    if (SDL_Init(SDL_INIT_VIDEO) < 0)
+    {
+        std::cout << "SDL could not be initialized: " << SDL_GetError();
+    }
+    else
+    {
         std::cout << "SDL video system is ready to go\n";
     }
 


### PR DESCRIPTION
Adds text to the top of the first tutorial file to assist Mac users in compiling the file.

Hello! 

I am following the Youtube tutorial and was having trouble compiling the cpp files on Mac. I understand that there is a solution posted on the Youtube channel. This solution required the use of the .framework file from the website instead of the homebrew install (in the homebrew install you would use a library instead of a framework and the include file is named "include"). I found the homebrew install method a little easier to understand.

I am a novice at all of this so I hope this is helpful.

Thanks!